### PR TITLE
Change behaviour: Makefiles had gcc/g++ hard-coded ignoring CC/CXX env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 # if CROSS is defined, we are building a cross compiler
 # possible targets are: win32, rpi
 
+ifeq ($(CC),)
+  CC=gcc
+endif
+
+ifeq ($(CXX),)
+  CXX=g++
+endif
+
 ifeq ($(CROSS),win32)
   CC=i686-w64-mingw32-gcc
   CXX=i686-w64-mingw32-g++
@@ -13,8 +21,6 @@ else ifeq ($(CROSS),rpi)
   EXT=
   BUILD=./build-rpi
 else
-  CC=gcc
-  CXX=g++
   EXT=
   BUILD=./build
 endif

--- a/PropellerCompiler/Makefile
+++ b/PropellerCompiler/Makefile
@@ -2,6 +2,14 @@
 # if CROSS is defined, we are building a cross compiler
 # possible targets are: win32, rpi
 
+ifeq ($(CC),)
+  CC=gcc
+endif
+
+ifeq ($(CXX),)
+  CXX=g++
+endif
+
 ifeq ($(CROSS),win32)
   CC=i686-w64-mingw32-gcc
   CXX=i686-w64-mingw32-g++
@@ -13,8 +21,6 @@ else ifeq ($(CROSS),rpi)
   EXT=
   BUILD=./build-rpi
 else
-  CC=gcc
-  CXX=g++
   EXT=
   BUILD=./build
 endif


### PR DESCRIPTION
As the Makefiles are currently written, they override the environmental variables set by CC and CXX as opposed to just setting values when they are undefined.

This PR changes it so that if CC / CXX are defined, then those values are used.  If CC / CXX is undefined, then gcc and g++ are set as defaults (as is the current configuration).

The need for the change is that I've started packaging up propeller tools into nix / nixos.

Originally I was just using their build-system to just patch those lines out.  This upstream patch is the better solution.

The nixpkgs PR for your reference can be found here: https://github.com/NixOS/nixpkgs/pull/46753

Thanks,


__red__ (from forums)
